### PR TITLE
Update workflow-style.qmd

### DIFF
--- a/workflow-style.qmd
+++ b/workflow-style.qmd
@@ -42,7 +42,8 @@ library(nycflights13)
       group_by(flight) |>
       summarize(
         delay = mean(arr_delay, na.rm = TRUE), 
-        cancelled = sum(is.na(arr_delay)), n = n()
+        cancelled = sum(is.na(arr_delay)), 
+        n = n()
       ) |>
       filter(n > 10)
     ```


### PR DESCRIPTION
Per the style guide, each named argument (including 'n') should be on its own line.